### PR TITLE
used JSONAssert lib for accurate JSON comparision

### DIFF
--- a/xchange-stream-coinbasepro/pom.xml
+++ b/xchange-stream-coinbasepro/pom.xml
@@ -19,6 +19,12 @@
             <version>${project.parent.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.skyscreamer</groupId>
+            <artifactId>jsonassert</artifactId>
+            <version>1.5.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.knowm.xchange</groupId>
             <artifactId>xchange-stream-service-netty</artifactId>
             <version>${project.parent.version}</version>

--- a/xchange-stream-coinbasepro/src/test/java/info/bitrich/xchangestream/coinbasepro/dto/CoinbaseProWebSocketSubscriptionMessageTest.java
+++ b/xchange-stream-coinbasepro/src/test/java/info/bitrich/xchangestream/coinbasepro/dto/CoinbaseProWebSocketSubscriptionMessageTest.java
@@ -4,15 +4,19 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import info.bitrich.xchangestream.core.ProductSubscription;
+
+import org.json.JSONException;
 import org.junit.Assert;
 import org.junit.Test;
 import org.knowm.xchange.currency.CurrencyPair;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
 
 /** Created by luca on 5/3/17. */
 public class CoinbaseProWebSocketSubscriptionMessageTest {
 
   @Test
-  public void testWebSocketMessageSerialization() throws JsonProcessingException {
+  public void testWebSocketMessageSerialization() throws JsonProcessingException, JSONException {
 
     ProductSubscription productSubscription =
         ProductSubscription.create()
@@ -28,13 +32,13 @@ public class CoinbaseProWebSocketSubscriptionMessageTest {
 
     String serialized = mapper.writeValueAsString(message);
 
-    Assert.assertEquals(
+    JSONAssert.assertEquals(
         "{\"type\":\"subscribe\",\"channels\":[{\"name\":\"matches\",\"product_ids\":[\"BTC-USD\"]},{\"name\":\"ticker\",\"product_ids\":[\"BTC-USD\"]},{\"name\":\"level2\",\"product_ids\":[\"BTC-USD\"]}]}",
-        serialized);
+        serialized, JSONCompareMode.NON_EXTENSIBLE);
   }
 
   @Test
-  public void testWebSocketMessageSerializationL3Orderbook() throws JsonProcessingException {
+  public void testWebSocketMessageSerializationL3Orderbook() throws JsonProcessingException, JSONException {
 
     ProductSubscription productSubscription =
         ProductSubscription.create()
@@ -50,13 +54,13 @@ public class CoinbaseProWebSocketSubscriptionMessageTest {
 
     String serialized = mapper.writeValueAsString(message);
 
-    Assert.assertEquals(
+    JSONAssert.assertEquals(
         "{\"type\":\"subscribe\",\"channels\":[{\"name\":\"matches\",\"product_ids\":[\"BTC-USD\"]},{\"name\":\"ticker\",\"product_ids\":[\"BTC-USD\"]},{\"name\":\"full\",\"product_ids\":[\"BTC-USD\"]}]}",
-        serialized);
+        serialized, JSONCompareMode.NON_EXTENSIBLE);
   }
 
   @Test
-  public void testWebSocketMessageSerializationBatch() throws JsonProcessingException {
+  public void testWebSocketMessageSerializationBatch() throws JsonProcessingException, JSONException {
 
     ProductSubscription productSubscription =
             ProductSubscription.create()
@@ -72,8 +76,8 @@ public class CoinbaseProWebSocketSubscriptionMessageTest {
 
     String serialized = mapper.writeValueAsString(message);
 
-    Assert.assertEquals(
+    JSONAssert.assertEquals(
             "{\"type\":\"subscribe\",\"channels\":[{\"name\":\"matches\",\"product_ids\":[\"BTC-USD\"]},{\"name\":\"level2_batch\",\"product_ids\":[\"BTC-USD\"]},{\"name\":\"ticker\",\"product_ids\":[\"BTC-USD\"]}]}",
-            serialized);
+            serialized, JSONCompareMode.NON_EXTENSIBLE);
   }
 }


### PR DESCRIPTION
### Description
This PR fixes the non deterministic behaviour of 3 tests in the module **xchange-stream-coinbasepro**
`info.bitrich.xchangestream.coinbasepro.dto.CoinbaseProWebSocketSubscriptionMessageTest#testWebSocketMessageSerializationBatch` `info.bitrich.xchangestream.coinbasepro.dto.CoinbaseProWebSocketSubscriptionMessageTest#testWebSocketMessageSerializationL3Orderbook`
`info.bitrich.xchangestream.coinbasepro.dto.CoinbaseProWebSocketSubscriptionMessageTest#testWebSocketMessageSerialization`
The flakiness/non-determinism detected using [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool.
### Steps to reproduce
```
git clone https://github.com/knowm/XChange
mvn install -pl xchange-stream-coinbasepro -am -DskipTests
mvn -pl xchange-stream-coinbasepro edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=info.bitrich.xchangestream.coinbasepro.dto.CoinbaseProWebSocketSubscriptionMessageTest.testWebSocketMessageSerialization
```
The test fails with 
```
[INFO] Running info.bitrich.xchangestream.coinbasepro.dto.CoinbaseProWebSocketSubscriptionMessageTest
[ERROR] Tests run: 3, Failures: 3, Errors: 0, Skipped: 0, Time elapsed: 0.410 s <<< FAILURE! -- in info.bitrich.xchangestream.coinbasepro.dto.CoinbaseProWebSocketSubscriptionMessageTest
[ERROR] info.bitrich.xchangestream.coinbasepro.dto.CoinbaseProWebSocketSubscriptionMessageTest.testWebSocketMessageSerializationBatch -- Time elapsed: 0.333 s <<< FAILURE!
org.junit.ComparisonFailure: expected:<{"[type":"subscribe","channels":[{"name":"matches","product_ids":["BTC-USD"]},{"name":"level2_batch","product_ids":["BTC-USD"]},{"name":"ticker","product_ids":["BTC-USD"]}]]}> but was:<{"[channels":[{"product_ids":["BTC-USD"],"name":"matches"},{"product_ids":["BTC-USD"],"name":"level2_batch"},{"product_ids":["BTC-USD"],"name":"ticker"}],"type":"subscribe"]}>
	at org.junit.Assert.assertEquals(Assert.java:117)
	at org.junit.Assert.assertEquals(Assert.java:146)
```
### Rootcause
The test attempts to serialize [CoinbaseProWebSocketSubscriptionMessage](https://github.com/knowm/XChange/blob/d56e61f2cf1368f917965a8c43f292a2a1b28ebc/xchange-stream-coinbasepro/src/main/java/info/bitrich/xchangestream/coinbasepro/dto/CoinbaseProWebSocketSubscriptionMessage.java#L114) using jackson library objectMapper and compares the generatedJSON string with hardcoded JSON string. However, This does not guarantee ordering of fields in the resulting JSON string because internally Jackson uses Java's getDeclaredFields() which is unordered [Doc](https://docs.oracle.com/javase/8/docs/api/java/lang/Class.html#getDeclaredFields--).

### Fix
used external library JSONAssert to assert the JSON reliably. It also has different compare [Modes](https://jsonassert.skyscreamer.org/apidocs/org/skyscreamer/jsonassert/JSONCompareMode.html). I have used  JSONCompareMode. NON_EXTENSIBLE which does not consider the order of contents in JSON string 

### verification
After the Fix, All the tests in class `CoinbaseProWebSocketSubscriptionMessageTest` pass. They also pass with`-DnondexRuns=50`
